### PR TITLE
Fix edit link for Drawio diagrams

### DIFF
--- a/DrawioEditor.php
+++ b/DrawioEditor.php
@@ -132,7 +132,7 @@ class DrawioEditor {
         /* display edit link */
         if (!$readonly) {
             $output .= '<div align="right">';
-	    $output .= '<span class="mw-editsection">';
+	    $output .= '<span class="mw-editdrawio">';
 	    $output .= '<span class="mw-editsection-bracket">[</span>';
             $output .= $edit_ahref;
             $output .= wfMessage('edit')->text().'</a>';


### PR DESCRIPTION
We should not use editsection syntax for drawio edit links, as they are
not normal section links, nor they have the same functions.

VE tries to parse drawio edit links and fails.

Needs cherry-pick to REL1_31

ERM: #12806